### PR TITLE
Fix empty numa nodes

### DIFF
--- a/src/architecture/parse_architecture.c
+++ b/src/architecture/parse_architecture.c
@@ -78,10 +78,15 @@ static int read_file_long_list(char* file, long int** result, int* length)
         long int read_cpu = strtol( current_ptr, &next_ptr, 10 );
         if ( next_ptr == current_ptr || errno !=0 )
         {
-            /* set error stream, might be an error, could also be just an empty file, since the numa node is empty */
+            /* maybe it's just an empty file? */
+            if (*current_ptr == '\n' || *current_ptr == '\0')
+               return 0;
+            /* otherwise sth went wrong */
             X86_ENERGY_SET_ERROR("Could not read next CPU: %s",current_ptr );
-            /* since we are not sure, we report no error and hope for the best */
-            return 0;
+            free(*result);
+            *result = NULL;
+            *length = 0;
+            return 1;
         }
         switch ( *next_ptr )
         {

--- a/src/architecture/parse_architecture.c
+++ b/src/architecture/parse_architecture.c
@@ -70,18 +70,19 @@ static int read_file_long_list(char* file, long int** result, int* length)
     char* current_ptr = buffer;
     char* next_ptr = NULL;
 
-
+    /* maybe it's just an empty file? */
+    if (*current_ptr == '\n' || *current_ptr == '\0')
+        return 0;
+        
     /*as long as strtol returns something valid, either !=0 or 0 with errno==0 */
     while ( 1 )
     {
         errno = 0;
+        
         long int read_cpu = strtol( current_ptr, &next_ptr, 10 );
         if ( next_ptr == current_ptr || errno !=0 )
         {
-            /* maybe it's just an empty file? */
-            if (*current_ptr == '\n' || *current_ptr == '\0')
-               return 0;
-            /* otherwise sth went wrong */
+            /* sth went wrong */
             X86_ENERGY_SET_ERROR("Could not read next CPU: %s",current_ptr );
             free(*result);
             *result = NULL;

--- a/src/architecture/parse_architecture.c
+++ b/src/architecture/parse_architecture.c
@@ -78,11 +78,10 @@ static int read_file_long_list(char* file, long int** result, int* length)
         long int read_cpu = strtol( current_ptr, &next_ptr, 10 );
         if ( next_ptr == current_ptr || errno !=0 )
         {
+            /* set error stream, might be an error, could also be just an empty file, since the numa node is empty */
             X86_ENERGY_SET_ERROR("Could not read next CPU: %s",current_ptr );
-            free(*result);
-            *result = NULL;
-            *length = 0;
-            return 1;
+            /* since we are not sure, we report no error and hope for the best */
+            return 0;
         }
         switch ( *next_ptr )
         {


### PR DESCRIPTION
This fix should enable support for NUMA nodes, which have no CPUs available (as seen on some Xeon Phi platforms and platforms with NVDIMM NUMA nodes