### PR TITLE
Add missing cstdint header

### DIFF
--- a/include/x86_energy.hpp
+++ b/include/x86_energy.hpp
@@ -14,6 +14,7 @@
 #include <string>
 #include <system_error>
 #include <vector>
+#include <cstdint>
 
 extern "C"
 {


### PR DESCRIPTION
Recent compilers complain about std::int32_t missing, so add the correct include.